### PR TITLE
espressif: fix RSA sign build after MbedTLS version update

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1364,7 +1364,7 @@ int boot_scramble_region_backwards(const struct flash_area *fa, uint32_t off, ui
     } else {
         uint8_t buf[BOOT_MAX_ALIGN];
         const size_t write_block = flash_area_align(fa);
-        uint32_t first_offset = ALIGN_DOWN(off, write_block);
+        first_offset = ALIGN_DOWN(off, write_block);
 
         memset(buf, flash_area_erased_val(fa), sizeof(buf));
 

--- a/boot/espressif/include/crypto_config/mbedtls_custom_config.h
+++ b/boot/espressif/include/crypto_config/mbedtls_custom_config.h
@@ -133,7 +133,7 @@
  *
  * Comment if your system does not support time functions
  */
-#define MBEDTLS_HAVE_TIME
+// #define MBEDTLS_HAVE_TIME
 
 /**
  * \def MBEDTLS_HAVE_TIME_DATE
@@ -154,7 +154,7 @@
  * mbedtls_platform_gmtime_r() at compile-time by using the macro
  * MBEDTLS_PLATFORM_GMTIME_R_ALT.
  */
-#define MBEDTLS_HAVE_TIME_DATE
+// #define MBEDTLS_HAVE_TIME_DATE
 
 /**
  * \def MBEDTLS_PLATFORM_MEMORY

--- a/boot/espressif/include/crypto_config/rsa.cmake
+++ b/boot/espressif/include/crypto_config/rsa.cmake
@@ -14,6 +14,8 @@ if (DEFINED CONFIG_ESP_USE_MBEDTLS)
         ${MBEDTLS_DIR}/library/sha256.c
         ${MBEDTLS_DIR}/library/rsa.c
         ${MBEDTLS_DIR}/library/bignum.c
+        ${MBEDTLS_DIR}/library/bignum_core.c
+        ${MBEDTLS_DIR}/library/constant_time.c
         ${MBEDTLS_DIR}/library/asn1parse.c
         ${MBEDTLS_DIR}/library/md.c
         ${MBEDTLS_DIR}/library/memory_buffer_alloc.c

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -109,6 +109,7 @@ fn main() {
             conf.file("../../ext/mbedtls/library/chachapoly.c");
             conf.file("../../ext/mbedtls/library/cipher.c");
             conf.file("../../ext/mbedtls/library/cipher_wrap.c");
+            conf.file("../../ext/mbedtls/library/constant_time.c");
             conf.file("../../ext/mbedtls/library/ctr_drbg.c");
             conf.file("../../ext/mbedtls/library/des.c");
             conf.file("../../ext/mbedtls/library/ecdsa.c");
@@ -131,7 +132,6 @@ fn main() {
             conf.file("../../ext/mbedtls/library/psa_crypto.c");
             conf.file("../../ext/mbedtls/library/psa_crypto_cipher.c");
             conf.file("../../ext/mbedtls/library/psa_crypto_client.c");
-            conf.file("../../ext/mbedtls/library/psa_crypto_driver_wrappers.c");
             conf.file("../../ext/mbedtls/library/psa_crypto_ecp.c");
             conf.file("../../ext/mbedtls/library/psa_crypto_hash.c");
             conf.file("../../ext/mbedtls/library/psa_crypto_mac.c");
@@ -139,6 +139,7 @@ fn main() {
             conf.file("../../ext/mbedtls/library/psa_crypto_slot_management.c");
             conf.file("../../ext/mbedtls/library/psa_crypto_storage.c");
             conf.file("../../ext/mbedtls/library/psa_its_file.c");
+            conf.file("../../ext/mbedtls/library/psa_util.c");
             conf.file("../../ext/mbedtls/library/ripemd160.c");
             conf.file("../../ext/mbedtls/library/rsa_alt_helpers.c");
             conf.file("../../ext/mbedtls/library/sha1.c");
@@ -170,6 +171,9 @@ fn main() {
 
         conf.file("../../ext/mbedtls/library/rsa.c");
         conf.file("../../ext/mbedtls/library/bignum.c");
+        conf.file("../../ext/mbedtls/library/bignum_core.c");
+        conf.file("../../ext/mbedtls/library/constant_time.c");
+        conf.file("../../ext/mbedtls/library/nist_kw.c");
         conf.file("../../ext/mbedtls/library/platform.c");
         conf.file("../../ext/mbedtls/library/platform_util.c");
         conf.file("../../ext/mbedtls/library/asn1parse.c");
@@ -203,6 +207,9 @@ fn main() {
 
         conf.file("../../ext/mbedtls/library/asn1parse.c");
         conf.file("../../ext/mbedtls/library/bignum.c");
+        conf.file("../../ext/mbedtls/library/bignum_core.c");
+        conf.file("../../ext/mbedtls/library/constant_time.c");
+        conf.file("../../ext/mbedtls/library/nist_kw.c");
         conf.file("../../ext/mbedtls/library/ecdsa.c");
         conf.file("../../ext/mbedtls/library/ecp.c");
         conf.file("../../ext/mbedtls/library/ecp_curves.c");
@@ -222,6 +229,9 @@ fn main() {
         conf.file("csupport/keys.c");
         conf.file("../../ext/mbedtls/library/asn1parse.c");
         conf.file("../../ext/mbedtls/library/bignum.c");
+        conf.file("../../ext/mbedtls/library/bignum_core.c");
+        conf.file("../../ext/mbedtls/library/constant_time.c");
+        conf.file("../../ext/mbedtls/library/nist_kw.c");
         conf.file("../../ext/mbedtls/library/ecp.c");
         conf.file("../../ext/mbedtls/library/ecp_curves.c");
         conf.file("../../ext/mbedtls/library/platform.c");
@@ -285,6 +295,9 @@ fn main() {
         conf.file("../../ext/mbedtls/library/md.c");
         conf.file("../../ext/mbedtls/library/aes.c");
         conf.file("../../ext/mbedtls/library/bignum.c");
+        conf.file("../../ext/mbedtls/library/bignum_core.c");
+        conf.file("../../ext/mbedtls/library/constant_time.c");
+        conf.file("../../ext/mbedtls/library/nist_kw.c");
         conf.file("../../ext/mbedtls/library/asn1parse.c");
     }
 
@@ -308,6 +321,7 @@ fn main() {
         conf.conf.include("../../ext/mbedtls/library");
         conf.file("../../ext/mbedtls/library/platform_util.c");
         conf.file("../../ext/mbedtls/library/nist_kw.c");
+        conf.file("../../ext/mbedtls/library/constant_time.c");
         conf.file("../../ext/mbedtls/library/cipher.c");
         conf.file("../../ext/mbedtls/library/cipher_wrap.c");
         conf.file("../../ext/mbedtls/library/aes.c");
@@ -372,6 +386,9 @@ fn main() {
         conf.file("../../ext/mbedtls/library/sha256.c");
         conf.file("../../ext/mbedtls/library/asn1parse.c");
         conf.file("../../ext/mbedtls/library/bignum.c");
+        conf.file("../../ext/mbedtls/library/bignum_core.c");
+        conf.file("../../ext/mbedtls/library/constant_time.c");
+        conf.file("../../ext/mbedtls/library/nist_kw.c");
         conf.file("../../ext/mbedtls/library/ecdh.c");
         conf.file("../../ext/mbedtls/library/md.c");
         conf.file("../../ext/mbedtls/library/aes.c");

--- a/sim/mcuboot-sys/csupport/config-ec-psa.h
+++ b/sim/mcuboot-sys/csupport/config-ec-psa.h
@@ -22,6 +22,7 @@
 #define MBEDTLS_BIGNUM_C
 #define MBEDTLS_MD_C
 #define MBEDTLS_OID_C
+#define MBEDTLS_CIPHER_C
 #if defined(MCUBOOT_SIGN_EC384)
 #define MBEDTLS_SHA384_C
 #define MBEDTLS_SHA512_C

--- a/sim/mcuboot-sys/csupport/config-rsa-kw.h
+++ b/sim/mcuboot-sys/csupport/config-rsa-kw.h
@@ -63,6 +63,7 @@
 
 /* mbed TLS modules */
 #define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
 #define MBEDTLS_BIGNUM_C
 #define MBEDTLS_MD_C
 #define MBEDTLS_OID_C
@@ -71,10 +72,6 @@
 #define MBEDTLS_AES_C
 #define MBEDTLS_CIPHER_C
 #define MBEDTLS_NIST_KW_C
-
-/* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             2048
-#define MBEDTLS_MPI_MAX_SIZE              256
 
 #define MBEDTLS_SSL_MAX_CONTENT_LEN 1024
 


### PR DESCRIPTION
Add missing files from external MbedTLS.